### PR TITLE
MinneHack 2022 Touchups

### DIFF
--- a/content/ctf.md
+++ b/content/ctf.md
@@ -6,8 +6,8 @@ navbar = "page"
 +++
 
 # CTF
-
-## We have a winner!
+More information regarding the MinneHack 2022 CTF will be announced during MinneHack's kickoff event!
+<!-- ## We have a winner!
 **Someone has already completed the CTF Mini-Hack and earned the top prize**. Don't worry, all hope
 is not lost! If you have solved it and you would like a special **MinneHack CTF badge** in luxurious
 **Grey PETG**, email acmctf at unown dot me (from the email address that you submitted to the endpoint with the correct flag!) with your physical address before the end of the
@@ -22,7 +22,5 @@ Since OpenSCAD files are version controllable, **he kept track of all his work w
 <http://ctf.mh.cult.fish>
 
 You're looking for a flag of the format `flag{sample_flag_text}`. _Make sure to include the `flag{}`
-text in your submission, otherwise the flag won't be accepted by the backend_.
+text in your submission, otherwise the flag won't be accepted by the backend_. -->
 
-
-<a href="/prompts">Back to prompts</a>

--- a/content/prompts.md
+++ b/content/prompts.md
@@ -7,28 +7,4 @@ navbar = "page"
 
 # Prompts
 
-This year's MinneHack prompts and their corresponding prizes are:
-
-* Water – taking a circular approach to the world’s most precious resource, helping customers manage water through conservation, recycling and reuse.
-   * Nintendo Switch
-* Food – keeping food safe all along the supply chain, preventing foodborne illnesses and ensuring safe, high-quality food for people around the world.
-   * Corsair K95 RGB Platinum XT Mechanical Keyboard and Logitech MX Master 3 Wireless Mouse
-* Health – protecting people and businesses from the risk of exposure to germs, keeping people healthy everywhere they eat, stay, play, shop and heal.
-   * Bose QuietComfort 35 II Wireless Bluetooth Headphones
-* Climate – tackling climate change by increasing energy efficiency and reducing greenhouse gas emissions – for customers and in operations.
-   * ASUS ProArt Display PA278QV 27” WQHD
-
-These prizes are per-person: each person on a team that wins their respective prompt gets the prize.
-
-## Mini-Hacks
-
-The Mini-Hack events (see the [schedule](/schedule) and [stream](https://www.twitch.tv/minnehack)
-for details!) have a separate prize pool.
-
-* [Code Golf](/codegolf)
-  * Blue Yeti Microphone & Logitech HD Pro Webcam C920
-* [Résumé Roast](https://chat.minnehack.io/channel/resume-roast-submissions)
-  * $200 of candy of the winner's choosing
-* [CTF](/ctf)
-  * ~~Pinephone Convergence Edition~~ Already claimed!
-  * MinneHack CTF badge -- see [the CTF page](/ctf) for details.
+The prompts for MinneHack 2022 will be announced on [the MinneHack Livestream](https://www.twitch.tv/minnehack) during the event's kickoff at 4:00PM CST on January 22nd, 2022. We hope to see you there!

--- a/content/schedule.md
+++ b/content/schedule.md
@@ -10,31 +10,45 @@ navbar = "page"
 Find out what's happening and when.
 
 <style>
-table { display: inline; }
+table { display: inline;}
+
+td, th {
+    border: 1px solid black; 
+    padding: 1rem;
+}
 
 td:nth-child(2) {
     white-space: nowrap;
 }
 </style>
 
-| Time     |         | Thing | |
-|----------|---------|---------------------|-|
-| Friday   | 6:00 PM | Find A Team | Looking for a team or need an extra member or two? This is the event for you! |
-| Saturday | 3:00 PM | Livestream Begins | MinneHack is live on twitch.tv/MinneHack - the stream will go live an hour before kickoff! |
-| Saturday | 4:00 PM | Kickoff! | The start of MinneHack! At this time we will introduce MinneHack, go over how the event will work, the prompt, and what we expect from a submission. Prizes and extra events taking place (called MiniHacks) will be covered. We will also have a short time for our partner organizations to speak. |
-| Saturday | 4:15 PM | Prompt is Posted | The prompt for MinneHack 2022 will be posted at this time, and can be found at https://minnehack.io/prompt |
-| Saturday | 4:30 PM | Team Forming in Discord | Individuals without a pre-formed team are invited to join the Discord voice channel #find-team to find others seeking a group for this year's competition. |
-| Saturday | 4:30 PM | First Mentor Shift Begins | Mentors from our sponsoring organizations will start being available. Most mentors will be logging off by 10:00PM CST, but a few may stay later. |
-| Saturday | 8:00 PM | CTF Opens | MinneHack partners MLH and USAF will be running a Capture the Flag event at this time. This is a cyber security challenge where you will solve puzzles and exploit vulnerabilities. |
-| Saturday | 8:30 PM | CTF Closes |  |
-| Saturday | 10:00 PM | Code Golf Opens | In this MiniHack event, you will be given a programming challenge (think Fibbonaci sequence) with the goal of implementing your function in as few characters as possible. The shortest submission wins a prize! |
-| Saturday | 11:00 PM | Code Golf Closes | Code Golf submissions are due at this time. |
-| Sunday | 12:00 AM | Resume Roast | Writing a good resume is hard, so we invite you to try your hand at writing your worst resume. Bring your midnight creativity and perhaps you'll leave with a prize! |
-| Sunday | 2:00 AM | MS Painting with Bob Ross | Chill out with us for a bit as we follow along with Bob Ross on stream using MS Paint. Open up your own canvas and send us your final product - a prize for the top submission! |
-| Sunday | 10:00 AM | Mentor Shift 2 Begins | At this time mentors from supporting organizations will be available online to help groups. |
-| Saturday | 12:00 PM | WereWolf | MLH will be running a game called Werewolf at this time. The game works similarly to 'Town of Salem'. Tune into the stream to learn more! |
-| Sunday | 2:00 PM | DevPost Tutorial | Need help with your DevPost submission? Tune into the stream to go through the process with MinneHack staff at this time. This presentation will cover everything you need to know to have a complete MinneHack submission. |
-| Sunday | 4:00 PM | Hacking Ends - Submission Cutoff | You must have your DevPost project submitted by this time. DevPost will automatically remove the option to submit your project after the deadline. If you are having trouble submitting your project, please contact MinneHack staff early so that we can assist. It is recommended to submit your project an hour before to avoid any unforseen hangups. |
-| Sunday | 4:00 PM | Mentor Shift 2 Ends | Mentors will no longer be online after this time. |
-| Sunday | 4:15 PM | Judging | We will play all the submission videos on stream for the judges to evaluate. You will also have the option to vote on your favorite projects, so tune in! |
-| Sunday | 6:00 PM | Closing Ceremonies | Closing ceremonies will begin at this time on the stream! Our event organizers and supporting sponsors will share some closing words. The winners will be announced on stream and published on DevPost at this time. Good Luck! |
+### Friday (January 21, 2022)
+| Time     | Event   | Description |
+|----------|---------|---------------------|
+| 6:00 PM | Find A Team | Looking for a team or need an extra member or two? This is the event for you! Finding a team for an online hackathon can be challenging, that’s why we’re hosting a Find-A-Team event on Friday, January 21st at 6:00PM. Come to the MinneHack Discord Server and join the #find-team channel. MinneHack staff will work with you to find group members to help you have the best hackathon experience possible! |
+
+### Saturday (January 22, 2022)
+| Time     | Event   | Description |
+|----------|---------|---------------------|
+| 3:00 PM | Livestream Begins | MinneHack is live on twitch.tv/MinneHack - the stream will go live an hour before kickoff! |
+| 4:00 PM | Kickoff! | The start of MinneHack! At this time we will introduce MinneHack, go over how the event will work, the prompt, and what we expect from a submission. Prizes and extra events taking place (called MiniHacks) will be covered. We will also have a short time for our partner organizations to speak. |
+4:15 PM | Prompt is Posted | The prompt for MinneHack 2022 will be posted at this time, and can be found at https://minnehack.io/prompt |
+4:30 PM | Team Forming in Discord | Individuals without a pre-formed team are invited to join the Discord voice channel #find-team to find others seeking a group for this year's competition. |
+4:30 PM | First Mentor Shift Begins | Mentors from our sponsoring organizations will start being available. Most mentors will be logging off by 10:00PM CST, but a few may stay later. |
+8:00 PM | CTF Opens | MinneHack partners MLH and USAF will be running a Capture the Flag event at this time. This is a cyber security challenge where you will solve puzzles and exploit vulnerabilities. |
+8:30 PM | CTF Closes |  |
+10:00 PM | Code Golf Opens | In this MiniHack event, you will be given a programming challenge (think Fibbonaci sequence) with the goal of implementing your function in as few characters as possible. The shortest submission wins a prize! |
+11:00 PM | Code Golf Closes | Code Golf submissions are due at this time. |
+
+### Sunday (January 23, 2022)
+| Time     | Event   | Description |
+|----------|---------|---------------------|
+| 12:00 AM | Resume Roast | Writing a good resume is hard, so we invite you to try your hand at writing your worst resume. Bring your midnight creativity and perhaps you'll leave with a prize! |
+| 2:00 AM | MS Painting with Bob Ross | Chill out with us for a bit as we follow along with Bob Ross on stream using MS Paint. Open up your own canvas and send us your final product - a prize for the top submission! |
+| 10:00 AM | Mentor Shift 2 Begins | At this time mentors from supporting organizations will be available online to help groups. |
+| 12:00 PM | WereWolf | MLH will be running a game called Werewolf at this time. The game works similarly to 'Town of Salem'. Tune into the stream to learn more! |
+| 2:00 PM | DevPost Tutorial | Need help with your DevPost submission? Tune into the stream to go through the process with MinneHack staff at this time. This presentation will cover everything you need to know to have a complete MinneHack submission. |
+| 4:00 PM | Hacking Ends - Submission Cutoff | You must have your DevPost project submitted by this time. DevPost will automatically remove the option to submit your project after the deadline. If you are having trouble submitting your project, please contact MinneHack staff early so that we can assist. It is recommended to submit your project an hour before to avoid any unforseen hangups. |
+| 4:00 PM | Mentor Shift 2 Ends | Mentors will no longer be online after this time. |
+| 4:15 PM | Judging | We will play all the submission videos on stream for the judges to evaluate. You will also have the option to vote on your favorite projects, so tune in! |
+| 6:00 PM | Closing Ceremonies | Closing ceremonies will begin at this time on the stream! Our event organizers and supporting sponsors will share some closing words. The winners will be announced on stream and published on DevPost at this time. Good Luck! |

--- a/templates/includes.html
+++ b/templates/includes.html
@@ -1,32 +1,33 @@
 {% macro links(signuphl=false) %}
-    <li><a href="/register">Register</a</li>
-	<li><a href="/faq">FAQ</a></li>
-	<li><a href="/sponsors">Sponsors</a></li>
-    <li><a href="/schedule">Schedule</a></li>
-    <li><a href="http://mlh.io/code-of-conduct">Code of Conduct</a></li>
+<li><a href="/register">Register</a< /li>
+<li><a href="/faq">FAQ</a></li>
+<li><a href="/sponsors">Sponsors</a></li>
+<li><a href="/schedule">Schedule</a></li>
+<li><a href="/prizes">Prizes</a></li>
+<li><a href="http://mlh.io/code-of-conduct">Code of Conduct</a></li>
 {% endmacro %}
 
 {% macro navbar(style) %}
-    <div class="navbar">
-        <div class="container">
-            {% if style == "title" %}
-                <ul class="title links">
-                    {{ includes::links(signuphl=false) }}
-                </ul>
-            {% elif style == "page" %}
-                <table>
-                    <tr>
-                        <td class="title">
-                            <h1><a href="/">MinneHack {{ config.extra.year }}</a></h1>
-                        </td>
-                        <td class="linkcell">
-                            <ul class="page links">
-                    			{{ includes::links(signuphl=true) }}
-                            </ul>
-                        </td>
-                    </tr>
-                </table>
-            {% endif %}
-        </div>
+<div class="navbar">
+    <div class="container">
+        {% if style == "title" %}
+        <ul class="title links">
+            {{ includes::links(signuphl=false) }}
+        </ul>
+        {% elif style == "page" %}
+        <table>
+            <tr>
+                <td class="title">
+                    <h1><a href="/">MinneHack {{ config.extra.year }}</a></h1>
+                </td>
+                <td class="linkcell">
+                    <ul class="page links">
+                        {{ includes::links(signuphl=true) }}
+                    </ul>
+                </td>
+            </tr>
+        </table>
+        {% endif %}
     </div>
+</div>
 {% endmacro %}


### PR DESCRIPTION
- Replace 2021 Content on CTF and Prompts pages
- Add Prizes link to navbar
- Split Schedule by day